### PR TITLE
Feature/fix tiling for large terrains

### DIFF
--- a/scripts/1_create_tiles.sh
+++ b/scripts/1_create_tiles.sh
@@ -7,7 +7,7 @@ start_zoom=15
 end_zoom=0
 tif_extension=TIF
 s_srs=EPSG:7415
-volume_mount=D:/dev/github.com/geodan/terrain/scripts
+volume_mount=/mnt/d/dev/github.com/geodan/terrain/scripts
 
 print_usage()
 {
@@ -60,6 +60,8 @@ then
     echo $output_dir directory created.
 fi
 
+: <<'END'
+
 # Check if input directory exists and has .tif files
 if ! compgen -G "${input_dir}/*${tif_extension}" > /dev/null; 
 then
@@ -77,12 +79,14 @@ for f in $(find ${input_dir}/*.${tif_extension}); do
     rm ${tmp_dir}/${filename}_filled.${tif_extension}
 done
 
+END
+
 echo Building virtual raster ${tmp_dir}/ahn.vrt...
 gdalbuildvrt -a_srs EPSG:4326 ${tmp_dir}/ahn.vrt ${tmp_dir}/*.${tif_extension} 
 
 # create quantized mesh tiles for level 15-9 using docker image tumgis/ctb-quantized-mesh
 # todo: use $pwd on Linux
-echo Running ctb-tile in Docker image...
+echo Running ctb-tile in Docker image...gdalbuild
 docker run -v ${volume_mount}:/data tumgis/ctb-quantized-mesh ctb-tile -f Mesh -C -N -e 9 -s ${start_zoom} -o ${output_dir} ${tmp_dir}/ahn.vrt
 
 # create layer.json file

--- a/scripts/1_create_tiles.sh
+++ b/scripts/1_create_tiles.sh
@@ -102,7 +102,7 @@ fi
 docker run -v ${volume_mount}:/data tumgis/ctb-quantized-mesh ctb-tile --output-format GTiff --output-dir ${tmplevel9} -s 9 -e 9 ${tmp_dir}/ahn.vrt
 
 # create VRT for GeoTIFF tiles on level 9
-gdalbuildvrt tmp/level9.vrt ./${tmplevel9}/9/*/*.tif
+gdalbuildvrt ${tmp_dir}/level9.vrt ./${tmplevel9}/9/*/*.tif
 
 # Make terrain tiles for level 8-0 
 docker run -v ${volume_mount}:/data tumgis/ctb-quantized-mesh ctb-tile -f Mesh -C -N -e ${end_zoom} -s 8 -l -o ${output_dir} ${tmp_dir}/level9.vrt

--- a/scripts/1_create_tiles.sh
+++ b/scripts/1_create_tiles.sh
@@ -60,7 +60,7 @@ then
     echo $output_dir directory created.
 fi
 
-: <<'END'
+# : <<'END'
 
 # Check if input directory exists and has .tif files
 if ! compgen -G "${input_dir}/*${tif_extension}" > /dev/null; 
@@ -79,7 +79,7 @@ for f in $(find ${input_dir}/*.${tif_extension}); do
     rm ${tmp_dir}/${filename}_filled.${tif_extension}
 done
 
-END
+# END
 
 echo Building virtual raster ${tmp_dir}/ahn.vrt...
 gdalbuildvrt -a_srs EPSG:4326 ${tmp_dir}/ahn.vrt ${tmp_dir}/*.${tif_extension} 
@@ -106,10 +106,10 @@ fi
 docker run -v ${volume_mount}:/data tumgis/ctb-quantized-mesh ctb-tile --output-format GTiff --output-dir ${tmplevel9} -s 9 -e 9 ${tmp_dir}/ahn.vrt
 
 # create VRT for GeoTIFF tiles on level 9
-gdalbuildvrt ${tmp_dir}/level9.vrt ./${tmplevel9}/9/*/*.tif
+gdalbuildvrt ${tmplevel9}/level9.vrt ./${tmplevel9}/9/*/*.tif
 
 # Make terrain tiles for level 8-0 
-docker run -v ${volume_mount}:/data tumgis/ctb-quantized-mesh ctb-tile -f Mesh -C -N -e ${end_zoom} -s 8 -o ${output_dir} ${tmp_dir}/level9.vrt
+docker run -v ${volume_mount}:/data tumgis/ctb-quantized-mesh ctb-tile -f Mesh -C -N -e ${end_zoom} -s 8 -o ${output_dir} ${tmplevel9}/level9.vrt
 
 # end workaround for level 8 - 0
 

--- a/scripts/1_create_tiles.sh
+++ b/scripts/1_create_tiles.sh
@@ -86,7 +86,7 @@ gdalbuildvrt -a_srs EPSG:4326 ${tmp_dir}/ahn.vrt ${tmp_dir}/*.${tif_extension}
 
 # create quantized mesh tiles for level 15-9 using docker image tumgis/ctb-quantized-mesh
 # todo: use $pwd on Linux
-echo Running ctb-tile in Docker image...gdalbuild
+echo Running ctb-tile in Docker image...
 docker run -v ${volume_mount}:/data tumgis/ctb-quantized-mesh ctb-tile -f Mesh -C -N -e 9 -s ${start_zoom} -o ${output_dir} ${tmp_dir}/ahn.vrt
 
 # create layer.json file
@@ -109,7 +109,7 @@ docker run -v ${volume_mount}:/data tumgis/ctb-quantized-mesh ctb-tile --output-
 gdalbuildvrt ${tmp_dir}/level9.vrt ./${tmplevel9}/9/*/*.tif
 
 # Make terrain tiles for level 8-0 
-docker run -v ${volume_mount}:/data tumgis/ctb-quantized-mesh ctb-tile -f Mesh -C -N -e ${end_zoom} -s 8 -l -o ${output_dir} ${tmp_dir}/level9.vrt
+docker run -v ${volume_mount}:/data tumgis/ctb-quantized-mesh ctb-tile -f Mesh -C -N -e ${end_zoom} -s 8 -o ${output_dir} ${tmp_dir}/level9.vrt
 
 # end workaround for level 8 - 0
 

--- a/scripts/1_create_tiles.sh
+++ b/scripts/1_create_tiles.sh
@@ -85,6 +85,9 @@ gdalbuildvrt -a_srs EPSG:4326 ${tmp_dir}/ahn.vrt ${tmp_dir}/*.${tif_extension}
 echo Running ctb-tile in Docker image...
 docker run -v ${volume_mount}:/data tumgis/ctb-quantized-mesh ctb-tile -f Mesh -C -N -e 9 -s ${start_zoom} -o ${output_dir} ${tmp_dir}/ahn.vrt
 
+# create layer.json file
+docker run -v ${volume_mount}:/data tumgis/ctb-quantized-mesh ctb-tile -f Mesh -C -N -e ${end_zoom} -s ${start_zoom} -l -o ${output_dir} ${tmp_dir}/ahn.vrt
+
 # start workaround for level 8 - 0
 
 # Create output directory


### PR DESCRIPTION
This is a workaround for the issue that the terrain tiler exits at level 8 (with overflow exceptions). It happens when tiling larger sets.

Workaround:

- Create terrain tiles for level 15-9

- Create GeoTIFFS for level 9

- Create VRT for level 9 GeoTIFFS

-  Create terrain tiles for level 8-0 based on VRT of level 9 