### PR TITLE
detect epsg code from first geotiff

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,9 @@ h Print this help
 
 When option -c is not used, warp will check the EPSG code of the first GeoTIFF.
 
-- If no EPSG code is detected or the EPSG code is 28992: the default s_srs is used (EPSG:7415)
+- If no EPSG code is detected or the EPSG code is 28992: the default s_srs is used (EPSG:7415). 
+EPSG:7415 is a composite of EPSG:28992 (horiontal) and EPSG:5709 (vertical) used in the Netherlands. 
+A the vertical EPSG code is optional but needed to transform from geoid to ellipsoid.
 - In other cases: the detected EPSG code is used as s_srs
 
 Sample output:

--- a/README.md
+++ b/README.md
@@ -150,21 +150,32 @@ m fillnodata maxdistance (in pixels) - default 100
 h Print this help
 ```
 
+When option -c is not used, warp will check the EPSG code of the first GeoTIFF.
+
+- If no EPSG code is detected or the EPSG code is 28992: the default s_srs is used (EPSG:7415)
+- In other cases: the detected EPSG code is used as s_srs
+
 Sample output:
 
 ```
-Terrain tiler 0.3 - Warp
-Start: Wed Jul 5 12:06:39 UTC 2023
+Terrain tiler 0.3.3 - Warp
+Start: Tue Jul 25 12:52:27 UTC 2023
 Temp directory: tmp
-Source SRS: EPSG:7415
+s_src input images:
 Fillnodata maxdistance: 100
+Delete tmp directory...
 tmp directory created.
-Start processing 256 GeoTIFFS...
-Processing DSM_1627_3855...
+s_srs not set, trying to detect it from first GeoTIFF
+EPSG of first tif: EPSG:28992
+make s_srs epsg:7415 in case of epsg:28992
+used s_srs: EPSG:7415
+Start processing 1 GeoTIFFS...
+100% 1:0=0s ./M5_32CN2.TIF
 Building virtual raster tmp/ahn.vrt...
+0...10...20...30...40...50...60...70...80...90...100 - done.
 VRT created: tmp/ahn.vrt
-End: Wed Jul 5 12:13:33 UTC 2023
-Elapsed time: 414 seconds.
+End: Tue Jul 25 12:52:28 UTC 2023
+Elapsed time: 1 seconds.
 End of processing
 ```
 

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ h Print this help
 When option -c is not used, warp will check the EPSG code of the first GeoTIFF.
 
 - If no EPSG code is detected or the EPSG code is 28992: the default s_srs is used (EPSG:7415). 
-EPSG:7415 is a composite of EPSG:28992 (horiontal) and EPSG:5709 (vertical) used in the Netherlands. 
+EPSG:7415 is a composite of EPSG:28992 (horizontal) and EPSG:5709 (vertical) used in the Netherlands. 
 A the vertical EPSG code is optional but needed to transform from geoid to ellipsoid.
 - In other cases: the detected EPSG code is used as s_srs
 

--- a/warp/process.sh
+++ b/warp/process.sh
@@ -88,13 +88,20 @@ then
     prefix="${epsg_first_tif:1:4}"
 
     if [[ $prefix == "EPSG" ]]; then
-        # real epsg code found in first tif
-        if [[ $epsg_first_tif == *"EPSG:28992" ]]
+        if [[ $epsg_first_tif != *"EPSG:-1" ]]
         then
-            echo make s_srs epsg:7415 in case of epsg:28992
-            s_srs=$default_s_srs
+            # real epsg code found in first tif
+            if [[ $epsg_first_tif == *"EPSG:28992" ]]
+            then
+                echo make s_srs epsg:7415 in case of epsg:28992
+                s_srs=$default_s_srs
+            else
+                s_srs=$epsg_first_tif
+            fi
         else
-            s_srs=$epsg_first_tif
+            echo EPSG not found from ${first_tif}:  ${epsg_first_tif}
+            echo Exit process...
+            exit 1
         fi
     else
         # no epsg code detected, for example: '_Confidence in this match: 25 % EPSG:28992 Confidence in this match: 25 % EPSG:28991_'

--- a/warp/process.sh
+++ b/warp/process.sh
@@ -53,7 +53,6 @@ do
 done
 
 echo Temp directory: $tmp_dir
-echo s_srs input images: $s_srs
 echo Fillnodata maxdistance: $md
 
 # Check if input directory has .tif files

--- a/warp/process.sh
+++ b/warp/process.sh
@@ -2,7 +2,8 @@
 
 version=0.3.3
 tmp_dir=tmp
-s_srs=EPSG:7415
+default_s_srs=EPSG:7415
+s_srs=""
 md=100
 
 echo Terrain tiler $version - Warp
@@ -52,7 +53,7 @@ do
 done
 
 echo Temp directory: $tmp_dir
-echo Source SRS: $s_srs
+echo s_srs input images: $s_srs
 echo Fillnodata maxdistance: $md
 
 # Check if input directory has .tif files
@@ -74,6 +75,38 @@ fi
 
 mkdir -p "$tmp_dir"
 echo $tmp_dir directory created.
+
+# Check on s_srs, if not set, try to find it from first GeoTIFF
+if [[ $s_srs == "" ]]
+then
+    echo s_srs not set, trying to detect it from first GeoTIFF...
+    # get the first tif
+    first_tif=$(find ./ -maxdepth 1 -type f -iname '*.tif' | head -1)
+    # get the epsg code
+    epsg_first_tif=$(gdalsrsinfo -o epsg $first_tif)
+
+    echo EPSG of first tif: ${epsg_first_tif} 
+    prefix="${epsg_first_tif:1:4}"
+
+    if [[ $prefix == "EPSG" ]]; then
+        # real epsg code found in first tif
+        if [[ $epsg_first_tif == *"EPSG:28992" ]]
+        then
+            echo make s_srs epsg:7415 in case of epsg:28992
+            s_srs=$default_s_srs
+        else
+            s_srs=$epsg_first_tif
+        fi
+    else
+        # no epsg code detected, for example: '_Confidence in this match: 25 % EPSG:28992 Confidence in this match: 25 % EPSG:28991_'
+        # use default epsg code instead
+        echo EPSG not found from ${first_tif}:  ${epsg_first_tif}
+        echo using default s_srs: $default_s_srs
+        s_srs=$default_s_srs
+    fi
+fi
+
+echo used s_srs: $s_srs
 
 warp_tiffs
 


### PR DESCRIPTION
Adding the following logic:

When option -c is not used, warp will check the EPSG code of the first GeoTIFF.

- If no EPSG code is detected or the EPSG code is 28992: the default s_srs is used (EPSG:7415)

- In other cases: the detected EPSG code is used as s_srs
