### PR TITLE
add tiler profile option

### DIFF
--- a/tiler/Dockerfile
+++ b/tiler/Dockerfile
@@ -3,5 +3,6 @@ RUN apk update && apk add parallel && apk add findutils && apk add gzip
 
 COPY process.sh /
 RUN chmod +x /process.sh
+RUN echo -ne "will cite" | parallel --citation || true
 
 ENTRYPOINT ["/process.sh"]

--- a/tiler/Dockerfile
+++ b/tiler/Dockerfile
@@ -1,5 +1,5 @@
-FROM tumgis/ctb-quantized-mesh
-RUN apt-get update && apt-get install -y parallel
+FROM tumgis/ctb-quantized-mesh:alpine
+RUN apk update && apk add parallel && apk add findutils && apk add gzip
 
 COPY process.sh /
 RUN chmod +x /process.sh

--- a/tiler/process.sh
+++ b/tiler/process.sh
@@ -111,8 +111,14 @@ echo Create vrt for GTiff tiles on level ${break_zoom}...
 gdalbuildvrt ${tmp_dir}/level${break_zoom}.vrt ./${tmp_dir}/${break_zoom}/*/*.tif
 
 # Make terrain tiles for level ${break_zoom}-1 to 0 
+echo
 echo Run ctb tile on level $((break_zoom-1)) to 0
 ctb-tile -v -f Mesh --profile ${profile} -C -N -e ${end_zoom} -s $((break_zoom-1)) -o ${output_dir} ${tmp_dir}/level${break_zoom}.vrt
+
+# clean up the temporary files
+echo Clean up temporary files...
+rm -rf ${tmp_dir}/level${break_zoom}.vrt
+rm -rf ./${tmp_dir}/${break_zoom}
 
 # end workaround for level break_zoom - 0
 

--- a/tiler/process.sh
+++ b/tiler/process.sh
@@ -106,10 +106,6 @@ echo Creating GTiff tiles for level ${break_zoom}...
 ctb-tile -v --output-format GTiff --profile ${profile} --output-dir ${tmp_dir} -s ${break_zoom} -e ${break_zoom} ${tmp_dir}/ahn.vrt
 echo 
 
-# set the projections the same for all GeoTIFF tiles on level break_zoom (workaround)
-echo Set projection for GTiff tiles on level ${break_zoom}...
-find ${tmp_dir}/${break_zoom} -name '*.tif' | parallel --bar 'gdalwarp -t_srs EPSG:4326 {} {}.tif && rm {}' 
-
 # create VRT for GeoTIFF tiles on level break_zoom
 echo Create vrt for GTiff tiles on level ${break_zoom}...
 gdalbuildvrt ${tmp_dir}/level${break_zoom}.vrt ./${tmp_dir}/${break_zoom}/*/*.tif


### PR DESCRIPTION
Adds a profile option to tiler - mercator/geodetic (default geodetic)

mercator profile has 1 tile at level 0, geodetic profile has 2 tiles at level 0 (left and right)

Generating the tiles with mercator profile is working, but it doesn't work yet in Cesium

Warning: In this pull request the Alpine image is used (tumgis/ctb-quantized-mesh:alpine), it has GDAL 3 so maybe there are some other changes.

